### PR TITLE
feat: busca task para id

### DIFF
--- a/back-end/src/controllers/task.controller.ts
+++ b/back-end/src/controllers/task.controller.ts
@@ -1,0 +1,98 @@
+import { Request, Response } from "express";
+import { TaskCreateDto } from "../interfaces/task";
+import { TaskService } from "../services/task.service";
+
+export class TaskController {
+    static async createTask(req: Request, res: Response): Promise<void> {
+        try {
+            const taskData: TaskCreateDto = req.body;
+
+            if (!taskData.title || !taskData.project_id) {
+                res.status(400).json({
+                    error: 'Campos obrigatórios: title e project_id'
+                });
+                return;
+            }
+
+            const newTask = await TaskService.createTask(taskData);
+
+            res.status(201).json({
+                message: 'Tarefa criada com sucesso',
+                task: newTask
+            });
+        } catch (error) {
+            if (error instanceof Error) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'Erro interno do servidor' });
+            }
+        }
+    }
+
+    static async getTasksByUserId(req: Request, res: Response): Promise<void> {
+        try {
+            const userId = parseInt(req.query.user_id as string);
+
+            if (!userId || isNaN(userId)) {
+                res.status(400).json({
+                    error: 'Parâmetro user_id é obrigatório e deve ser um número'
+                });
+                return;
+            }
+
+            const tasks = await TaskService.getTasksByUserId(userId);
+
+            res.status(200).json({
+                message: 'Tarefas encontradas',
+                tasks: tasks
+            });
+        } catch (error) {
+            if (error instanceof Error) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'Erro interno do servidor' });
+            }
+        }
+    }
+
+    static async getTaskById(req: Request, res: Response): Promise<void> {
+        try {
+            const taskId = parseInt(req.params.id as string);
+            const userId = parseInt(req.query.user_id as string);
+
+            if (!taskId || isNaN(taskId)) {
+                res.status(400).json({
+                    error: 'ID da tarefa deve ser um número válido'
+                });
+                return;
+            }
+
+            if (!userId || isNaN(userId)) {
+                res.status(400).json({
+                    error: 'Parâmetro user_id é obrigatório e deve ser um número'
+                });
+                return;
+            }
+
+            const task = await TaskService.getTaskById(taskId, userId);
+
+            if (!task) {
+                res.status(404).json({
+                    error: 'Tarefa não encontrada ou não pertence ao usuário'
+                });
+                return;
+            }
+
+            res.status(200).json({
+                message: 'Tarefa encontrada',
+                task: task
+            });
+        } catch (error) {
+            if (error instanceof Error) {
+                res.status(400).json({ error: error.message });
+            } else {
+                res.status(500).json({ error: 'Erro interno do servidor' });
+            }
+        }
+    }
+}

--- a/back-end/src/interfaces/task.ts
+++ b/back-end/src/interfaces/task.ts
@@ -1,0 +1,14 @@
+export interface Task {
+    id: number;
+    title: string;
+    description?: string;
+    tip?: string;
+    priority?: string;
+    status?: string;
+    estimate?: number;
+    project_id: number;
+}
+
+export type TaskCreateDto = Omit<Task, 'id'>;
+
+export type TaskResponseDTO = Task;

--- a/back-end/src/repositories/task.repository.ts
+++ b/back-end/src/repositories/task.repository.ts
@@ -1,0 +1,50 @@
+import { db } from "../database/db";
+import { Task, TaskCreateDto } from "../interfaces/task";
+
+export class TaskRepository {
+    static create(taskData: TaskCreateDto): number {
+        const result = db.prepare(`
+            INSERT INTO tasks (title, description, tip, priority, status, estimate, project_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        `).run(
+            taskData.title,
+            taskData.description || null,
+            taskData.tip || null,
+            taskData.priority || null,
+            taskData.status || null,
+            taskData.estimate || null,
+            taskData.project_id
+        );
+
+        if (result.changes === 0) {
+            throw new Error('Falha ao inserir tarefa no banco de dados');
+        }
+
+        return result.lastInsertRowid as number;
+    }
+
+    static findById(id: number): Task | undefined {
+        return db.prepare(`
+            SELECT id, title, description, tip, priority, status, estimate, project_id
+            FROM tasks
+            WHERE id = ?
+        `).get(id) as Task | undefined;
+    }
+
+    static findByProjectId(projectId: number): Task[] {
+        return db.prepare(`
+            SELECT id, title, description, tip, priority, status, estimate, project_id
+            FROM tasks
+            WHERE project_id = ?
+        `).all(projectId) as Task[];
+    }
+
+    static findByUserId(userId: number): Task[] {
+        return db.prepare(`
+            SELECT t.id, t.title, t.description, t.tip, t.priority, t.status, t.estimate, t.project_id
+            FROM tasks t
+            INNER JOIN projects p ON t.project_id = p.id
+            WHERE p.user_id = ?
+        `).all(userId) as Task[];
+    }
+}

--- a/back-end/src/routes/task.routes.ts
+++ b/back-end/src/routes/task.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { TaskController } from "../controllers/task.controller";
+
+const tasksRoutes = Router();
+
+tasksRoutes.post("/", TaskController.createTask);
+tasksRoutes.get("/", TaskController.getTasksByUserId);
+tasksRoutes.get("/:id", TaskController.getTaskById);
+tasksRoutes.post("/:id", () => {});
+
+export default tasksRoutes;

--- a/back-end/src/services/task.service.ts
+++ b/back-end/src/services/task.service.ts
@@ -1,0 +1,80 @@
+import { TaskCreateDto, TaskResponseDTO } from "../interfaces/task";
+import { TaskRepository } from "../repositories/task.repository";
+import { TaskValidation } from "../validations/task.validation";
+
+export class TaskService {
+    static async createTask(taskData: TaskCreateDto): Promise<TaskResponseDTO> {
+        // Validações
+        if (!TaskValidation.validateTitle(taskData.title)) {
+            throw new Error('Título é obrigatório e deve ter pelo menos 1 caractere');
+        }
+
+        if (!TaskValidation.validateProjectId(taskData.project_id)) {
+            throw new Error('ID do projeto é obrigatório e deve ser válido');
+        }
+
+        if (!TaskValidation.validateDescription(taskData.description)) {
+            throw new Error('Descrição inválida');
+        }
+
+        if (!TaskValidation.validatePriority(taskData.priority)) {
+            throw new Error('Prioridade deve ser low, medium ou high');
+        }
+
+        if (!TaskValidation.validateStatus(taskData.status)) {
+            throw new Error('Status deve ser pending, in_progress ou completed');
+        }
+
+        if (!TaskValidation.validateEstimate(taskData.estimate)) {
+            throw new Error('Estimativa deve ser um número positivo');
+        }
+
+        // Criar tarefa
+        const taskId = TaskRepository.create(taskData);
+
+        // Buscar tarefa criada
+        const newTask = TaskRepository.findById(taskId);
+
+        if (!newTask) {
+            throw new Error('Erro ao criar tarefa');
+        }
+
+        return newTask;
+    }
+
+    static async getTasksByUserId(userId: number): Promise<TaskResponseDTO[]> {
+        if (!userId || userId <= 0) {
+            throw new Error('ID do usuário é obrigatório e deve ser válido');
+        }
+
+        const tasks = TaskRepository.findByUserId(userId);
+        return tasks;
+    }
+
+    static async getTaskById(taskId: number, userId: number): Promise<TaskResponseDTO | null> {
+        if (!taskId || taskId <= 0) {
+            throw new Error('ID da tarefa é obrigatório e deve ser válido');
+        }
+
+        if (!userId || userId <= 0) {
+            throw new Error('ID do usuário é obrigatório e deve ser válido');
+        }
+
+        // Buscar a tarefa
+        const task = TaskRepository.findById(taskId);
+
+        if (!task) {
+            return null;
+        }
+
+        // Verificar se a tarefa pertence a um projeto do usuário
+        const userTasks = TaskRepository.findByUserId(userId);
+        const belongsToUser = userTasks.some((t: TaskResponseDTO) => t.id === taskId);
+
+        if (!belongsToUser) {
+            return null;
+        }
+
+        return task;
+    }
+}

--- a/back-end/src/validations/task.validation.ts
+++ b/back-end/src/validations/task.validation.ts
@@ -1,0 +1,31 @@
+export class TaskValidation {
+    static validateTitle(title: string): boolean {
+        return title.trim().length >= 1;
+    }
+
+    static validateDescription(description?: string): boolean {
+        if (!description) return true; // opcional
+        return description.trim().length >= 0;
+    }
+
+    static validatePriority(priority?: string): boolean {
+        if (!priority) return true;
+        const validPriorities = ['low', 'medium', 'high'];
+        return validPriorities.includes(priority.toLowerCase());
+    }
+
+    static validateStatus(status?: string): boolean {
+        if (!status) return true;
+        const validStatuses = ['pending', 'in_progress', 'completed'];
+        return validStatuses.includes(status.toLowerCase());
+    }
+
+    static validateEstimate(estimate?: number): boolean {
+        if (estimate === undefined) return true;
+        return estimate >= 0;
+    }
+
+    static validateProjectId(projectId: number): boolean {
+        return projectId > 0;
+    }
+}


### PR DESCRIPTION
Endpoint para buscar uma task específica por ID, garantindo que ela pertence ao usuário.

Como usar:
Faça uma requisição **GET** para /tasks/1?user_id=2, onde:

1 é o ID da task
2 é o ID do usuário (para verificar permissão)

Exemplo de resposta bem-sucedida:
_**{
  "message": "Tarefa encontrada",
  "task": {
    "id": 1,
    "title": "Minha tarefa",
    "description": "Descrição",
    "priority": "high",
    "status": "pending",
    "estimate": 2,
    "project_id": 1
  }
}**_

Se a task não existir ou não pertencer ao usuário:
**_{
  "error": "Tarefa não encontrada ou não pertence ao usuário"
}_**
