### PR TITLE
fix:resolve-links-quebrados-em-notificacoes

### DIFF
--- a/front-end/src/components/NotificationPopup/NotificationPopup.ts
+++ b/front-end/src/components/NotificationPopup/NotificationPopup.ts
@@ -3,6 +3,7 @@ import { InviteService } from '../../services/InviteService';
 import { Notification, NotificationType, parseNotificationData } from '../../models/Collaboration';
 import template from './NotificationPopup.html';
 import './NotificationPopup.css';
+import { app } from '../../App';
 
 export class NotificationPopup {
     private container: HTMLElement;
@@ -253,7 +254,7 @@ export class NotificationPopup {
         // Navigate based on type
         const data = parseNotificationData(notification.data);
         if (data?.project_id) {
-            window.location.href = `/projetos/${data.project_id}`;
+            app.navigate(`/projetos/${data.project_id}`);
             this.close();
         }
     }

--- a/front-end/src/views/Notifications/NotificationsView.ts
+++ b/front-end/src/views/Notifications/NotificationsView.ts
@@ -4,6 +4,7 @@ import './NotificationsView.css';
 import { NotificationService } from "../../services/NotificationService";
 import { InviteService } from "../../services/InviteService";
 import { Notification, NotificationType, parseNotificationData } from "../../models/Collaboration";
+import { app } from '../../App';
 
 export class NotificationsView extends Component {
     private currentPage: number = 1;
@@ -138,7 +139,7 @@ export class NotificationsView extends Component {
                 item.style.cursor = 'pointer';
                 item.addEventListener('click', () => {
                     if (!n.read) this.markAsRead(n.id);
-                    window.location.href = `/projetos/${data.project_id}`;
+                    app.navigate(`/projetos/${data.project_id}`);
                 });
             }
 


### PR DESCRIPTION
### Causa do Problema:
1. A aplicação usa uma arquitetura SPA (Single Page Application) com um Router personalizado
2. O Router está configurado com um basePath: '/server02' ([Router.ts:27](vscode-webview://1ib4agck7jba3v05iv14k36uc59iorhne7b0ks0n17op0lnk46g9/To-do-List/front-end/src/core/Router.ts#L27))
3. As notificações estavam usando window.location.href diretamente, o que:
- Não adicionava o prefixo /server02 necessário
- Causava um recarregamento completo da página ao invés de usar a navegação SPA
- Resultava em URLs incompletas como /projetos/123 ao invés de /server02/projetos/123

### Correções Aplicadas:
1. [NotificationsView.ts:141](vscode-webview://1ib4agck7jba3v05iv14k36uc59iorhne7b0ks0n17op0lnk46g9/To-do-List/front-end/src/views/Notifications/NotificationsView.ts#L141)

- ❌ Antes: window.location.href = /projetos/${data.project_id};
- ✅ Depois: app.navigate(/projetos/${data.project_id});

2. [NotificationPopup.ts:256](vscode-webview://1ib4agck7jba3v05iv14k36uc59iorhne7b0ks0n17op0lnk46g9/To-do-List/front-end/src/components/NotificationPopup/NotificationPopup.ts#L256)

- ❌ Antes: window.location.href = /projetos/${data.project_id};
- ✅ Depois: app.navigate(/projetos/${data.project_id});

3. Imports adicionados:

- Adicionei import { app } from '../../App'; em ambos os arquivos

### Resultado:
Agora os links das notificações funcionam corretamente, usando:

- A navegação SPA do Router (sem recarregar a página)
- O basePath correto (/server02)
- Navegação suave e rápida entre as páginas